### PR TITLE
[Fix] Allow testing resources with multiple extensions

### DIFF
--- a/scim2_client/client.py
+++ b/scim2_client/client.py
@@ -552,13 +552,13 @@ class SCIMClient:
         for schema, resource_type in resource_types_by_schema.items():
             schema_obj = schema_objs_by_schema[schema]
             model = Resource.from_schema(schema_obj)
-            extensions = []
+            extensions = ()
             for ext_schema in resource_type.schema_extensions or []:
                 schema_obj = schema_objs_by_schema[ext_schema.schema_]
                 extension = Extension.from_schema(schema_obj)
-                extensions.append(extension)
+                extensions = extensions + (extension,)
             if extensions:
-                model = model[tuple(extensions)]
+                model = model[Union[extensions]]
             resource_models.append(model)
 
         return tuple(resource_models)


### PR DESCRIPTION
If a server advertises a resource with multiple extensions scim2-client will fail with:
```
  File "/usr/local/lib/python3.11/site-packages/pydantic/_internal/_generics.py", line 373, in map_generic_model_arguments
    raise TypeError(f'Too many arguments for {cls}; actual {len(args)}, expected {expected_len}')
TypeError: Too many arguments for <class 'scim2_models.rfc7643.schema.User'>; actual 3, expected 1
```

The problem here is that a tuple is used as container for the Generic `AnyExtension` but it must be a `Union` to make pydantic happy. The scim2-models also checks if the type is a `Union`.